### PR TITLE
Fixed bug with re-running programs from xgdb

### DIFF
--- a/lib/JIT.cpp
+++ b/lib/JIT.cpp
@@ -291,9 +291,11 @@ void JITImpl::reclaimUnreachableFunctions(JITCoreInfo &coreInfo)
       info->fastFuncValue
     };
     for (LLVMValueRef f : functions) {
-      LLVMFreeMachineCodeForFunction(executionEngine, f);
-      LLVMReplaceAllUsesWith(f, LLVMGetUndef(LLVMTypeOf(f)));
-      LLVMDeleteFunction(f);
+      if(f){
+        LLVMFreeMachineCodeForFunction(executionEngine, f);
+        LLVMReplaceAllUsesWith(f, LLVMGetUndef(LLVMTypeOf(f)));
+        LLVMDeleteFunction(f);
+      }
     }
     info->fastFunc = nullptr;
     info->func = nullptr;


### PR DESCRIPTION
This could be better implemented, but post-run the structure in
reclaimUnreachableFunctions contains null ptrs, which causes
segmentation faults.

There's probably a better solution, but this works for now.
